### PR TITLE
Let local configurations reside outside the source tree

### DIFF
--- a/snakeskin/factory.py
+++ b/snakeskin/factory.py
@@ -25,20 +25,27 @@ def load_configs(app):
     On app creation, load and and override configs in the following order:
      - config/default.py
      - config/{SNAKESKIN_ENV}.py
-     - config/{SNAKESKIN_ENV}-local.py (excluded from version control; sensitive values go here)
+     - {SNAKESKIN_LOCAL_CONFIGS}/{SNAKESKIN_ENV}-local.py (excluded from version control; sensitive values go here)
     """
-    load_config(app, 'default')
+    load_module_config(app, 'default')
     # SNAKESKIN_ENV defaults to 'development'.
     snakeskin_env = os.environ.get('SNAKESKIN_ENV', 'development')
-    load_config(app, snakeskin_env)
-    load_config(app, '{}-local'.format(snakeskin_env))
+    load_module_config(app, snakeskin_env)
+    load_local_config(app, '{}-local.py'.format(snakeskin_env))
 
 
-def load_config(app, config_name):
-    """Load an individual configuration file if it exists."""
+def load_module_config(app, config_name):
+    """Load an individual module-hosted configuration file if it exists."""
     config_path = 'config.{}'.format(config_name)
     if importlib.util.find_spec(config_path) is not None:
         app.config.from_object(config_path)
+
+
+def load_local_config(app, config_name):
+    """Load the local configuration file (if any) from a location outside the package."""
+    configs_location = os.environ.get('SNAKESKIN_LOCAL_CONFIGS') or '../config/'
+    config_path = configs_location + config_name
+    app.config.from_pyfile(config_path, silent=True)
 
 
 def register_routes(app):


### PR DESCRIPTION
Flask docs say:
"You should not use `from_object` to load the actual configuration but
rather configuration defaults.  The actual config should be loaded
with `from_pyfile` and ideally from a location not within the
package because the package might be installed system wide."