### PR TITLE
LA-133 Some basic error handling, project cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,3 @@ config/*-local.py
 
 # Python virtual environment
 venv
-

--- a/config/default.py
+++ b/config/default.py
@@ -1,9 +1,6 @@
 import os
 
 
-# Development environment.
-DEBUG = True
-
 # Base directory.
 BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 
@@ -26,3 +23,6 @@ EDO_ORACLE_PORT = ''
 EDO_ORACLE_SID = ''
 EDO_ORACLE_USERNAME = ''
 EDO_ORACLE_PASSWORD = ''
+
+HOST = '0.0.0.0'
+PORT = 5000

--- a/config/development.py
+++ b/config/development.py
@@ -1,0 +1,2 @@
+# Development environment.
+DEBUG = True

--- a/run.py
+++ b/run.py
@@ -1,4 +1,5 @@
-from snakeskin import app
+from snakeskin.factory import create_app
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=5000, debug=True)
+    app = create_app()
+    app.run(host=app.config['HOST'], port=app.config['PORT'])

--- a/snakeskin/__init__.py
+++ b/snakeskin/__init__.py
@@ -1,7 +1,0 @@
-from snakeskin import factory
-
-app = factory.create_app()
-db = factory.initialize_db(app)
-
-# Route registration depends on the database being in place (because of dependencies on models).
-factory.register_routes(app)

--- a/snakeskin/api/errors.py
+++ b/snakeskin/api/errors.py
@@ -1,0 +1,42 @@
+from flask import jsonify
+from flask import current_app as app
+
+
+class JsonableException(Exception):
+    def __init__(self, message):
+        Exception.__init__(self)
+        self.message = message
+
+    def to_json(self):
+        if self.message:
+            return jsonify({'message': self.message})
+        else:
+            return ''
+
+
+class BadRequestError(JsonableException): pass
+class UnauthorizedRequestError(JsonableException): pass
+class ForbiddenRequestError(JsonableException): pass
+class ResourceNotFoundError(JsonableException): pass
+
+
+@app.errorhandler(BadRequestError)
+def handle_bad_request(error):
+    return error.to_json(), 400
+
+@app.errorhandler(UnauthorizedRequestError)
+def handle_unauthorized(error):
+    return error.to_json(), 401
+
+@app.errorhandler(ForbiddenRequestError)
+def handle_resource_not_found(error):
+    return error.to_json(), 403
+
+@app.errorhandler(ResourceNotFoundError)
+def handle_resource_not_found(error):
+    return error.to_json(), 404
+
+@app.errorhandler(Exception)
+def handle_unexpected_error(error):
+    app.logger.exception(error)
+    return jsonify({'message': 'An unexpected server error occurred.'}), 500

--- a/snakeskin/api/tenant_controller.py
+++ b/snakeskin/api/tenant_controller.py
@@ -1,5 +1,6 @@
 from flask import Blueprint, jsonify
 
+from snakeskin.api.errors import ResourceNotFoundError
 from snakeskin.models.tenant import Tenant
 
 
@@ -13,4 +14,7 @@ def show_tenants():
 @tenant.route('/<tenant_id>')
 def show_tenant_profile(tenant_id):
     tenant = Tenant.query.filter_by(id=tenant_id).first()
+    if tenant is None:
+        raise ResourceNotFoundError('The requested tenant could not be found.')
+
     return jsonify(tenant.full_profile())

--- a/snakeskin/api/user_controller.py
+++ b/snakeskin/api/user_controller.py
@@ -1,40 +1,43 @@
-from flask import Blueprint, jsonify
+from flask import Blueprint, g, jsonify
 
-from snakeskin.models.tenant import Tenant
+from snakeskin.api.errors import ResourceNotFoundError
 from snakeskin.models.user import User
 
 
 user = Blueprint('user', __name__, url_prefix='/api/tenant/<tenant_id>/user/<external_id>')
 
+
+@user.url_value_preprocessor
+def fetch_user(endpoint, values):
+    user = User.query.filter_by(tenant_id=values['tenant_id'], external_id=values['external_id']).first()
+    if user is None:
+        raise ResourceNotFoundError('The requested user could not be found.')
+    else:
+        g.user = user
+
 @user.route('/')
 def show_user_profile(tenant_id, external_id):
-    tenant = Tenant.query.filter_by(id=tenant_id).first()
-    user = User.query.filter_by(tenant_id=tenant_id, external_id=external_id).first()
     return jsonify({
-        'tenant': tenant.short_profile(),
-        'user': user.full_profile()
+        'tenant': g.user.tenant.short_profile(),
+        'user': g.user.full_profile()
     })
 
 @user.route('/data_sources')
 def show_user_data_sources(tenant_id, external_id):
-    user = User.query.filter_by(tenant_id=tenant_id, external_id=external_id).first()
-    result = user.get_data_sources()
+    result = g.user.get_data_sources()
     return jsonify(result)
 
 @user.route('/recent_activities')
 def show_user_recent_activities(tenant_id, external_id):
-    user = User.query.filter_by(tenant_id=tenant_id, external_id=external_id).first()
-    result = user.get_recent_activities()
+    result = g.user.get_recent_activities()
     return jsonify(result)
 
 @user.route('/top_activities')
 def show_user_top_activities(tenant_id, external_id):
-    user = User.query.filter_by(tenant_id=tenant_id, external_id=external_id).first()
-    result = user.get_top_activities()
+    result = g.user.get_top_activities()
     return jsonify(result)
 
 @user.route('/total_activities')
 def show_user_total_activities(tenant_id, external_id):
-    user = User.query.filter_by(tenant_id=tenant_id, external_id=external_id).first()
-    result = user.get_total_activities()
+    result = g.user.get_total_activities()
     return jsonify(result)

--- a/snakeskin/configs.py
+++ b/snakeskin/configs.py
@@ -1,0 +1,30 @@
+import importlib.util
+import os
+
+
+def load_configs(app):
+    """
+    On app creation, load and and override configs in the following order:
+     - config/default.py
+     - config/{SNAKESKIN_ENV}.py
+     - {SNAKESKIN_LOCAL_CONFIGS}/{SNAKESKIN_ENV}-local.py (excluded from version control; sensitive values go here)
+    """
+    load_module_config(app, 'default')
+    # SNAKESKIN_ENV defaults to 'development'.
+    snakeskin_env = os.environ.get('SNAKESKIN_ENV', 'development')
+    load_module_config(app, snakeskin_env)
+    load_local_config(app, '{}-local.py'.format(snakeskin_env))
+
+
+def load_module_config(app, config_name):
+    """Load an individual module-hosted configuration file if it exists."""
+    config_path = 'config.{}'.format(config_name)
+    if importlib.util.find_spec(config_path) is not None:
+        app.config.from_object(config_path)
+
+
+def load_local_config(app, config_name):
+    """Load the local configuration file (if any) from a location outside the package."""
+    configs_location = os.environ.get('SNAKESKIN_LOCAL_CONFIGS') or '../config/'
+    config_path = configs_location + config_name
+    app.config.from_pyfile(config_path, silent=True)

--- a/snakeskin/db.py
+++ b/snakeskin/db.py
@@ -1,0 +1,7 @@
+from flask_sqlalchemy import SQLAlchemy
+
+db = SQLAlchemy()
+
+def initialize_db(app):
+    db.init_app(app)
+    return db

--- a/snakeskin/factory.py
+++ b/snakeskin/factory.py
@@ -1,64 +1,18 @@
-import importlib.util
-import os
+from flask import Flask
 
-from flask import Flask, make_response
-from flask_sqlalchemy import SQLAlchemy
-
-db = SQLAlchemy()
+from snakeskin.configs import load_configs
+from snakeskin.db import initialize_db
+from snakeskin.routes import register_routes
 
 
 def create_app():
     """Initialize app with configs."""
     app = Flask(__name__.split('.')[0])
+
     load_configs(app)
+    initialize_db(app)
+
+    with app.app_context():
+        register_routes(app)
+
     return app
-
-
-def initialize_db(app):
-    """Initialize database object."""
-    db.init_app(app)
-    return db
-
-
-def load_configs(app):
-    """
-    On app creation, load and and override configs in the following order:
-     - config/default.py
-     - config/{SNAKESKIN_ENV}.py
-     - {SNAKESKIN_LOCAL_CONFIGS}/{SNAKESKIN_ENV}-local.py (excluded from version control; sensitive values go here)
-    """
-    load_module_config(app, 'default')
-    # SNAKESKIN_ENV defaults to 'development'.
-    snakeskin_env = os.environ.get('SNAKESKIN_ENV', 'development')
-    load_module_config(app, snakeskin_env)
-    load_local_config(app, '{}-local.py'.format(snakeskin_env))
-
-
-def load_module_config(app, config_name):
-    """Load an individual module-hosted configuration file if it exists."""
-    config_path = 'config.{}'.format(config_name)
-    if importlib.util.find_spec(config_path) is not None:
-        app.config.from_object(config_path)
-
-
-def load_local_config(app, config_name):
-    """Load the local configuration file (if any) from a location outside the package."""
-    configs_location = os.environ.get('SNAKESKIN_LOCAL_CONFIGS') or '../config/'
-    config_path = configs_location + config_name
-    app.config.from_pyfile(config_path, silent=True)
-
-
-def register_routes(app):
-    """Register app routes."""
-
-    # Register API routes as blueprints.
-    from snakeskin.api.tenant_controller import tenant
-    from snakeskin.api.user_controller import user
-    app.register_blueprint(tenant)
-    app.register_blueprint(user)
-
-    # Routes not matched by the API are handled by the front end.
-    @app.route('/', defaults={'path': ''})
-    @app.route('/<path:path>')
-    def front_end_route(**kwargs):
-        return make_response(open('snakeskin/templates/index.html').read())

--- a/snakeskin/models/base.py
+++ b/snakeskin/models/base.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from snakeskin import db
+from snakeskin.db import db
 
 
 """

--- a/snakeskin/models/credential.py
+++ b/snakeskin/models/credential.py
@@ -1,4 +1,4 @@
-from snakeskin import db
+from snakeskin.db import db
 from snakeskin.models.base import Base
 
 

--- a/snakeskin/models/opt_out.py
+++ b/snakeskin/models/opt_out.py
@@ -1,4 +1,4 @@
-from snakeskin import db
+from snakeskin.db import db
 from snakeskin.models.base import Base
 
 

--- a/snakeskin/models/statement.py
+++ b/snakeskin/models/statement.py
@@ -1,4 +1,4 @@
-from snakeskin import db
+from snakeskin.db import db
 from snakeskin.models.base import Base
 
 

--- a/snakeskin/models/tenant.py
+++ b/snakeskin/models/tenant.py
@@ -1,4 +1,4 @@
-from snakeskin import db
+from snakeskin.db import db
 from snakeskin.models.base import Base
 from snakeskin.proxies import canvas
 
@@ -38,4 +38,7 @@ class Tenant(Base):
 
     def get_user_profile(self, user):
         response = canvas.get_user_for_sis_id(self, user.external_id)
-        return response.json()
+        if response:
+            return response.json()
+        else:
+            return None

--- a/snakeskin/models/user.py
+++ b/snakeskin/models/user.py
@@ -1,6 +1,6 @@
 from sqlalchemy import sql
 
-from snakeskin import db
+from snakeskin.db import db
 from snakeskin.models.base import Base
 from snakeskin.proxies import edo_oracle
 
@@ -34,10 +34,17 @@ class User(Base):
         }
 
     def full_profile(self):
-        profile = self.tenant.get_user_profile(self)
-        profile.update(edo_oracle.get_bio_data(self.external_id))
-        profile.update(self.short_profile())
+        profile = {}
 
+        canvas_user_profile = self.tenant.get_user_profile(self)
+        if canvas_user_profile:
+            profile.update(canvas_user_profile)
+
+        oracle_bio_data = edo_oracle.get_bio_data(self.external_id)
+        if oracle_bio_data:
+            profile.update(oracle_bio_data)
+
+        profile.update(self.short_profile())
         return profile
 
     def get_data_sources(self):

--- a/snakeskin/proxies/canvas.py
+++ b/snakeskin/proxies/canvas.py
@@ -1,6 +1,8 @@
 import requests
 import urllib
 
+from flask import current_app as app
+
 
 def get_user_for_sis_id(canvas_instance, sis_id):
     path = '/api/v1/users/sis_user_id:UID:{}'.format(sis_id)
@@ -18,5 +20,11 @@ def request(canvas_instance, path):
     ])
     auth_headers = {'Authorization': 'Bearer {}'.format(canvas_instance.token)}
 
-    response = requests.get(url, headers=auth_headers)
-    return response
+    try:
+        response = requests.get(url, headers=auth_headers)
+        response.raise_for_status()
+    except requests.exceptions.RequestException as e:
+        app.logger.error(e)
+        return None
+    else:
+        return response

--- a/snakeskin/proxies/edo_oracle.py
+++ b/snakeskin/proxies/edo_oracle.py
@@ -1,25 +1,33 @@
 import cx_Oracle
 
-from snakeskin import app
+from flask import current_app as app
 
 
 def get_bio_data(user_id):
     sql = ('SELECT GENDER_GENDEROFRECORD_CODE, BIRTH_DATE, EMAIL_EMAILADDRESS, ADDRESS_HOME_CITY '
              'FROM SISEDO.PERSONV00_VW '
              'WHERE IDENTIFIER_CAMPUSUID_ID = :user_id ')
-    return query(sql, user_id=user_id)[0]
+    results = query(sql, user_id=user_id)
+
+    if results:
+        return results[0]
+    else:
+        return None
 
 def query(sql, **params):
     dsn = cx_Oracle.makedsn(app.config['EDO_ORACLE_HOST'], app.config['EDO_ORACLE_PORT'], app.config['EDO_ORACLE_SID'])
-    db = cx_Oracle.connect(app.config['EDO_ORACLE_USERNAME'], app.config['EDO_ORACLE_PASSWORD'], dsn)
-    cursor = db.cursor()
 
-    result = cursor.execute(sql, **params)
-    rows = result.fetchall()
-    columns = [i[0].lower() for i in cursor.description]
-    zipped = [dict(zip(columns, row)) for row in rows]
+    try:
+        with cx_Oracle.connect(app.config['EDO_ORACLE_USERNAME'], app.config['EDO_ORACLE_PASSWORD'], dsn) as db:
+            cursor = db.cursor()
+            result = cursor.execute(sql, **params)
+            rows = result.fetchall()
+            columns = [i[0].lower() for i in cursor.description]
+            zipped = [dict(zip(columns, row)) for row in rows]
+            cursor.close()
 
-    cursor.close()
-    db.close()
+    except cx_Oracle.DatabaseError as e:
+        app.logger.error(e)
+        zipped = None
 
     return zipped

--- a/snakeskin/routes.py
+++ b/snakeskin/routes.py
@@ -1,0 +1,25 @@
+from flask import make_response
+
+
+def register_routes(app):
+    """Register app routes."""
+
+    # Register API routes as blueprints.
+    from snakeskin.api.tenant_controller import tenant
+    from snakeskin.api.user_controller import user
+    app.register_blueprint(tenant)
+    app.register_blueprint(user)
+
+    # Error handling.
+    import snakeskin.api.errors
+
+    # Unmatched API routes return a 404.
+    @app.route('/api/<path:path>')
+    def handle_unmatched_api_route(**kwargs):
+        raise snakeskin.api.errors.ResourceNotFoundError('The requested resource could not be found.')
+
+    # Non-API routes are handled by the front end.
+    @app.route('/', defaults={'path': ''})
+    @app.route('/<path:path>')
+    def front_end_route(**kwargs):
+        return make_response(open('snakeskin/templates/index.html').read())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,8 @@
 import os
 import subprocess
 
-from snakeskin import factory
+import snakeskin.db
+import snakeskin.factory
 
 from tests.fixtures.tenants import *
 
@@ -11,8 +12,7 @@ os.environ['SNAKESKIN_ENV'] = 'test'
 @pytest.fixture(scope='session')
 def app(request):
     '''Fixture application object.'''
-    _app = factory.create_app()
-    factory.register_routes(_app)
+    _app = snakeskin.factory.create_app()
 
     # Create app context before running tests.
     ctx = _app.app_context()
@@ -29,8 +29,7 @@ def app(request):
 @pytest.fixture(scope='session')
 def db(app, request):
     '''Fixture database object.'''
-    _db = factory.initialize_db(app)
-    _db.app = app
+    _db = snakeskin.db.initialize_db(app)
 
     # The psycopg2 engine doesn't handle big pg_dump files well, so shell out to load the schema. Abort the
     # transaction and test suite if the schema contains errors.

--- a/tests/test_api/test_api_errors.py
+++ b/tests/test_api/test_api_errors.py
@@ -1,0 +1,13 @@
+class TestApiErrors:
+    '''API error handling'''
+    def test_api_route_not_found(self, client):
+        '''returns a 404 for unknown API routes'''
+        response = client.get('/api/rumpus/')
+        assert response.status_code == 404
+        assert response.json['message'] == 'The requested resource could not be found.'
+
+    def test_non_api_route_not_found(self, client):
+        '''serves front-end template for unknown non-API routes'''
+        response = client.get('/rumpus/')
+        assert response.status_code == 200
+        assert '<title>Snakeskin</title>' in str(response.data)

--- a/tests/test_api/test_tenant_controller.py
+++ b/tests/test_api/test_tenant_controller.py
@@ -1,13 +1,26 @@
 class TestTenantController:
     '''Tenant API'''
-    def test_tenant_api(self, client, fixture_tenants):
+    def test_tenants_list(self, client, fixture_tenants):
         '''returns a well-formed response'''
         response = client.get('/api/tenant/')
         assert response.status_code == 200
         assert len(response.json) == 2
 
-        assert response.json[0]['id'] is not None
+        assert response.json[0]['id'] == fixture_tenants[0].id
         assert response.json[0]['name'] == 'UC Berkeley'
 
-        assert response.json[1]['id'] is not None
+        assert response.json[1]['id'] == fixture_tenants[1].id
         assert response.json[1]['name'] == 'UC Online Education'
+
+    def test_tenant_single(self, client, fixture_tenants):
+        '''returns a single tenant'''
+        response = client.get('/api/tenant/{}'.format(fixture_tenants[0].id))
+        assert response.status_code == 200
+        assert response.json['id'] == fixture_tenants[0].id
+        assert response.json['name'] == 'UC Berkeley'
+
+    def test_tenant_not_found(self, client, fixture_tenants):
+        '''returns 404 for an unknown id'''
+        response = client.get('/api/tenant/99999')
+        assert response.status_code == 404
+        assert response.json['message'] == 'The requested tenant could not be found.'


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/LA-133

Latest out of the labs:

- Before exploring flask-restful, pad out our blueprint-based views with basic error handling. Follow the docs in raising custom exceptions for errors we anticipate, followed by a catchall for those we don't (http://flask.pocoo.org/docs/0.12/patterns/apierrors/).
- The app factory is further cleaned up, with different concerns (config, database, routes) extracted into their own top-level modules. `__init__.py` becomes a completely empty file, so that when the `snakeskin` module is imported by other code (e.g., tests), surprise extra app instances are not created. Flask's `current_app` utility is used when code needs access to the app object (e.g., logging, configs).
- It turns out one nice thing about blueprints is that blueprint-specific `url_value_preprocessor` decorators work more or less like a Rails `before_filter`. See usage in `user_controller.py`.
- Errors in external data sources are logged and return `None` responses to higher-level code - in this case, the `User.full_profile` method, which tries to degrade as gracefully as it can.
- Debug mode is turned on in the development environment only.