### PR TITLE
LA-170 Fake/fixture patterns for TDD and demo mode

### DIFF
--- a/config/demo.py
+++ b/config/demo.py
@@ -1,0 +1,1 @@
+DEBUG = True

--- a/fixtures/canvas_user_for_sis_id_2040.json
+++ b/fixtures/canvas_user_for_sis_id_2040.json
@@ -1,0 +1,17 @@
+{
+  "id": 10001,
+  "name": "Oliver Heyer",
+  "sortable_name": "Heyer, Oliver",
+  "short_name": "Oliver Heyer",
+  "sis_user_id": "UID:2040",
+  "integration_id": null,
+  "sis_login_id": "2040",
+  "sis_import_id": 12345678,
+  "login_id": "2040",
+  "avatar_url": "https://upload.wikimedia.org/wikipedia/en/thumb/b/b4/Donald_Duck.svg/618px-Donald_Duck.svg.png",
+  "locale": null,
+  "permissions": {
+    "can_update_name": false,
+    "can_update_avatar": true
+  }
+}

--- a/fixtures/canvas_user_for_sis_id_242881.json
+++ b/fixtures/canvas_user_for_sis_id_242881.json
@@ -1,0 +1,17 @@
+{
+  "id": 10002,
+  "name": "Paul Kerschen",
+  "sortable_name": "Kerschen, Paul",
+  "short_name": "Paul Kerschen",
+  "sis_user_id": "UID:242881",
+  "integration_id": null,
+  "sis_login_id": "242881",
+  "sis_import_id": 123456,
+  "login_id": "242881",
+  "avatar_url": "https://en.wikipedia.org/wiki/Daffy_Duck#/media/File:Daffy_Duck.svg",
+  "locale": null,
+  "permissions": {
+    "can_update_name": false,
+    "can_update_avatar": true
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,10 @@ Flask-Login
 Flask-SQLAlchemy
 SQLAlchemy
 cx_Oracle
+httpretty
 psycopg2
 pytest
+pytest-catchlog
 pytest-flask
 requests
 https://github.com/python-cas/python-cas/archive/master.zip

--- a/snakeskin/lib/http.py
+++ b/snakeskin/lib/http.py
@@ -1,0 +1,15 @@
+import requests
+
+from flask import current_app as app
+
+def request(url, headers):
+    app.logger.debug({'message': 'HTTP request', 'url': url, 'headers': headers})
+    try:
+        # TODO handle methods other than GET
+        response = requests.get(url, headers=headers)
+        response.raise_for_status()
+    except requests.exceptions.RequestException as e:
+        app.logger.error(e)
+        return None
+    else:
+        return response

--- a/snakeskin/lib/mockingbird.py
+++ b/snakeskin/lib/mockingbird.py
@@ -1,0 +1,154 @@
+from contextlib import contextmanager
+from functools import partial, wraps
+import httpretty
+import os
+
+from flask import current_app
+
+"""This module wraps the httpretty package to return fake external API responses in test or demo mode.
+
+A module can define mock behavior by using the @mockable decorator on a function that calls an external URL, and the
+@mocking decorator on a function that returns the fake response.
+
+A test function can temporarily substitute custom mock behavior with the register_mock context manager.
+"""
+
+
+class MockResponse:
+    """A callable object that can be passed into httpretty's register_uri method with the 'body' keyword. (Despite
+    that keyword's name, it takes a tuple including status and headers as well as response body.)
+
+    Functions that use the @mocking decorator should return a MockResponse object.
+
+    The register_mock context manager may pass in a MockResponse object, or, if dynamic behavior is required, a function
+    that returns a MockResponse object.
+    """
+    def __init__(self, status, headers, body):
+        self.status = status
+        self.headers = headers
+        self.body = body
+
+    def __call__(self, *args):
+        return (self.status, self.headers, self.body)
+
+
+"""Registry associating mockable request functions with zero or more mock response functions. Responses are arranged
+in a last-in-first-out queue so that test code can temporarily substitute custom mocks."""
+_mock_registry = {}
+
+
+def _register_mock(request_function, response_function):
+    _mock_registry[request_function.__name__].append(response_function)
+
+
+def _unregister_mock(request_function):
+    _mock_registry[request_function.__name__].pop()
+
+
+def mockable(func):
+    """Decorator marking a function as mockable. Since httpretty registers mock responses against URLs, the function
+    to be decorated must generate (or have access to) the complete URL to be called.
+
+    Functions using this decorator should accept an optional 'mock' argument. The decorator will replace this argument
+    with a context manager that activates the mock response currently associated to the mockable function in the
+    registry.
+
+    Usage:
+
+    @mockable
+    def call_external_api(hostname, resource_id, mock=None):
+        ...
+        url = 'http://{}/resource/{}'.format(hostname, resource_id)
+        ...
+        with mock(url):
+            response = requests.get(url)
+            ...
+    """
+    _mock_registry[func.__name__] = []
+
+    @wraps(func)
+    def mockable_wrapper(*args, **kw):
+        if _environment_supports_mocks() and _mock_registry.get(func.__name__):
+            mock_response = _mock_registry[func.__name__][-1](*args, **kw)
+            kw['mock'] = partial(_activate_mock, mock_response=mock_response)
+        else:
+            kw['mock'] = _noop_mock
+        return func(*args, **kw)
+    return mockable_wrapper
+
+
+def mocking(request_func):
+    """Decorator marking a function that returns a mock response. The function to be mocked should be supplied to the
+    decorator as an argument. The decorated function will be called with the same arguments as the function to be
+    mocked (apart from the optional 'mock' argument) and may generate a dynamic response.
+
+    Usage:
+
+    @mocking(call_external_api)
+    def external_api_mock(hostname, resource_id):
+        return MockResponse(200, {}, json.dumps({'id': resource_id}))
+    """
+    @wraps(request_func)
+    def register_mock_for_request_func(func):
+        if _environment_supports_mocks():
+            _register_mock(request_func, func)
+        return func
+    return register_mock_for_request_func
+
+
+def fixture(fixture_file):
+    """Convenience function to generate a mock response from a fixture filename. If a matching fixture is found, return
+    200 with the fixture body. If a matching fixture is not found, return a generic 404.
+
+    Usage:
+
+    @mocking(call_external_api)
+    def external_api_mock(hostname, resource_id):
+        return fixture('resource_{}_feed.json'.format(resource_id))
+    """
+    path = current_app.config['BASE_DIR'] + '/../fixtures/{}'.format(fixture_file)
+    try:
+        file = open(path)
+    except FileNotFoundError:
+        return MockResponse(404, {}, '{"message": "The requested resource was not found."}')
+    with file:
+        fixture = file.read()
+        return MockResponse(200, {}, fixture)
+
+
+@contextmanager
+def register_mock(request_function, response):
+    """Context manager, intended to be used from tests, that temporarily registers a mock response for a given request.
+    A MockResponse object may be supplied, or, if dynamic behavior is required, a function that returns a MockResponse."""
+    if isinstance(response, MockResponse):
+        response_function = lambda *args: response
+    else:
+        response_function = response
+
+    _register_mock(request_function, response_function)
+    yield
+    _unregister_mock(request_function)
+
+
+@contextmanager
+def _activate_mock(url, mock_response):
+    if mock_response and _environment_supports_mocks():
+        httpretty.enable()
+        # TODO handle methods other than GET
+        httpretty.register_uri(httpretty.GET, url, body=mock_response)
+        yield
+        httpretty.disable()
+    else:
+        yield
+
+
+# It would be nicer to use a MOCKS_ENABLED config value rather than a hardcoded list of environments, but tests are
+# currently set up such that this code is loaded before app config is in place.
+def _environment_supports_mocks():
+    env = os.environ.get('SNAKESKIN_ENV')
+    return (env == 'test' or env == 'demo')
+
+
+@contextmanager
+def _noop_mock(url):
+    yield None

--- a/snakeskin/models/tenant.py
+++ b/snakeskin/models/tenant.py
@@ -23,8 +23,11 @@ class Tenant(Base):
     domain = db.Column(db.String(255))
     token = db.Column(db.String(255))
 
-    def __init__(self, name):
+    def __init__(self, name, scheme=None, domain=None, token=None):
         self.name = name
+        self.scheme = scheme
+        self.domain = domain
+        self.token = token
 
     def __repr__(self):
         return '<Tenant %r>' % (self.name)

--- a/snakeskin/proxies/canvas.py
+++ b/snakeskin/proxies/canvas.py
@@ -1,30 +1,28 @@
-import requests
 import urllib
 
-from flask import current_app as app
+from snakeskin.lib import http
+from snakeskin.lib.mockingbird import fixture, mockable, mocking
 
 
-def get_user_for_sis_id(canvas_instance, sis_id):
-    path = '/api/v1/users/sis_user_id:UID:{}'.format(sis_id)
-    return request(canvas_instance, path)
-
-
-def request(canvas_instance, path):
-    url = urllib.parse.urlunparse([
-      canvas_instance.scheme,
-      canvas_instance.domain,
-      urllib.parse.quote(path),
-      '',
-      '',
-      ''
-    ])
+@mockable
+def get_user_for_sis_id(canvas_instance, sis_id, mock=None):
+    url = build_url(canvas_instance, '/api/v1/users/sis_user_id:UID:{}'.format(sis_id))
     auth_headers = {'Authorization': 'Bearer {}'.format(canvas_instance.token)}
+    with mock(url):
+        return http.request(url, auth_headers)
 
-    try:
-        response = requests.get(url, headers=auth_headers)
-        response.raise_for_status()
-    except requests.exceptions.RequestException as e:
-        app.logger.error(e)
-        return None
-    else:
-        return response
+
+@mocking(get_user_for_sis_id)
+def get_user_for_sis_id_fixture(canvas_instance, sis_id):
+    return fixture('canvas_user_for_sis_id_{}.json'.format(sis_id))
+
+
+def build_url(canvas_instance, path):
+    return urllib.parse.urlunparse([
+        canvas_instance.scheme,
+        canvas_instance.domain,
+        urllib.parse.quote(path),
+        '',
+        '',
+        ''
+    ])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,12 @@
 import os
 import subprocess
 
+os.environ['SNAKESKIN_ENV'] = 'test'
+
 import snakeskin.db
 import snakeskin.factory
-
 from tests.fixtures.tenants import *
 
-os.environ['SNAKESKIN_ENV'] = 'test'
 
 # Because app and db fixtures are only created once per pytest run, individual tests
 # are not able to modify application configuration values before the app is created.

--- a/tests/fixtures/tenants.py
+++ b/tests/fixtures/tenants.py
@@ -1,12 +1,12 @@
 import pytest
-
 from snakeskin.models.tenant import Tenant
 
-
 @pytest.fixture
-def fixture_tenants(db_session):
-    ucb = Tenant(name='UC Berkeley')
-    ucoe = Tenant(name='UC Online Education')
+def fixture_tenants(app, db_session):
+
+    ucb = Tenant(name='UC Berkeley', scheme='https', domain='bcourses.berkeley.edu', token='secret')
+    ucoe = Tenant(name='UC Online Education', scheme='https', domain='cole2.uconline.edu', token='secret')
+
     db_session.add(ucb)
     db_session.add(ucoe)
     db_session.commit()

--- a/tests/test_proxies/test_canvas.py
+++ b/tests/test_proxies/test_canvas.py
@@ -1,0 +1,39 @@
+import pytest
+
+from snakeskin.lib.mockingbird import MockResponse, register_mock
+import snakeskin.proxies.canvas as canvas
+
+
+@pytest.fixture
+def ucb_canvas(fixture_tenants):
+    return fixture_tenants[0]
+
+
+class TestCanvasGetUserForSisId:
+    '''Canvas API query (user for SIS ID)'''
+
+    def test_user_for_sis_id(self, ucb_canvas):
+        '''returns fixture data'''
+        oliver_response = canvas.get_user_for_sis_id(ucb_canvas, 2040)
+        assert oliver_response.status_code == 200
+        assert oliver_response.json()['sortable_name'] == 'Heyer, Oliver'
+        assert oliver_response.json()['avatar_url'] == 'https://upload.wikimedia.org/wikipedia/en/thumb/b/b4/Donald_Duck.svg/618px-Donald_Duck.svg.png'
+
+        paul_response = canvas.get_user_for_sis_id(ucb_canvas, 242881)
+        assert paul_response.status_code == 200
+        assert paul_response.json()['sortable_name'] == 'Kerschen, Paul'
+        assert paul_response.json()['avatar_url'] == 'https://en.wikipedia.org/wiki/Daffy_Duck#/media/File:Daffy_Duck.svg'
+
+    def test_user_not_found(self, ucb_canvas, caplog):
+        '''logs 404 for unknown user and returns empty response'''
+        response = canvas.get_user_for_sis_id(ucb_canvas, 9999999)
+        assert 'HTTP/1.1" 404' in caplog.text
+        assert not response
+
+    def test_server_error(self, ucb_canvas, caplog):
+        '''logs unexpected server errors and returns empty response'''
+        canvas_error = MockResponse(500, {}, '{"message": "Internal server error."}')
+        with register_mock(canvas.get_user_for_sis_id, canvas_error):
+            response = canvas.get_user_for_sis_id(ucb_canvas, 2040)
+            assert 'HTTP/1.1" 500' in caplog.text
+            assert not response


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/LA-170

This PR shares some patterns that leverage the httpretty web-mocking package for tests and a demo mode.

Object-oriented proxies with a "fake" attribute, as in Junction, would allow for a pattern similar to Junction's Mockable code. _However_, little birds have told me that functional style may be preferable to object-oriented style in Python web development; so I've experimented with decorators and context managers for a pattern that might look more like idiomatic Python, though it has no pretensions to fooling a native speaker.

This PR is perhaps best read from the bottom up, first looking at example usage on the Canvas API calls, and then at the way mockingbird.py is implemented.

The code is activated under SNAKESKIN_ENV=test (pytest runs) and SNAKESKIN_ENV=demo (identical to development mode except for mocks). Creating a `demo-local.py` identical to `development-local.py` makes it easy to switch between real and fake API calls.

Screenshot from `python run.py` (real Canvas):
<img width="819" alt="screen shot 2017-09-05 at 10 53 43 am" src="https://user-images.githubusercontent.com/2413467/30075089-993400de-9228-11e7-86f6-afb1db0b0cdc.png">

Screenshot from `SNAKESKIN_ENV=demo python run.py` (fake Canvas):
<img width="778" alt="screen shot 2017-09-05 at 10 54 09 am" src="https://user-images.githubusercontent.com/2413467/30075092-9cf13f84-9228-11e7-84fb-470626fa26d5.png">

